### PR TITLE
i18n: fallback when pattern in catalog is empty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ install:
 - cp -v .travis.ant.local ant.local
 
 script:
-- ant compile test jdoc
+- ant travis

--- a/build.xml
+++ b/build.xml
@@ -22,4 +22,6 @@ support a course on "Distributed Systems"
 
 <target name="default" depends="compile,compile-pitfill" />
 
+<target name="travis" depends="compile,test,compile-pitfill,jdoc" />
+
 </project>

--- a/src/main/java/pityoulish/i18n/CatalogHelper.java
+++ b/src/main/java/pityoulish/i18n/CatalogHelper.java
@@ -58,28 +58,47 @@ public final class CatalogHelper
       ResourceBundle bundle = getBundle(tref);
       String pattern = bundle.getString(tref.getKey());
 
-      // This call parses the pattern. If patterns are used frequently, they
-      // should be parsed only once and the resulting MessageFormat cached.
-      // That's not necessary for the programming exercises though.
-      result = MessageFormat.format(pattern, params);
+      if (pattern.length() > 0)
+       {
+         // This call parses the pattern. If patterns are used frequently, they
+         // should be parsed only once and the resulting MessageFormat cached.
+         // That's not necessary for the programming exercises though.
+         result = MessageFormat.format(pattern, params);
+       }
+      else
+       {
+         // an empty pattern is an invalid catalog entry, provide a fallback
+         result = fallbackFormat(tref, params);
+       }
 
     } catch (MissingResourceException mre) {
       // the lookup failed, provide a fallback
-
-      StringBuilder sb = new StringBuilder(80);
-      sb.append(tref.getBundleName()).append("::").append(tref.getKey());
-      for(Object param : params)
-         sb.append(" \"").append(param).append("\"");
-
-      result = sb.toString();
+      result = fallbackFormat(tref, params);
     }
-    // ClassCastException intentionally not handled here,
+    // ClassCastException from bundle.getString intentionally not handled here,
     // because TextRef should always refer to a text.
     // IllegalArgumentException intentionally not handled here,
     // because it indicates a bad resource or a mismatch
     // between resource bundle and code.
 
     return result;
+  }
+
+
+  /**
+   * Formats parameters in case a pattern is missing.
+   *
+   * @param tref        text ref of the missing pattern
+   * @param params      parameters to format
+   */
+  protected static final String fallbackFormat(TextRef tref, Object... params)
+  {
+    StringBuilder sb = new StringBuilder(80);
+    sb.append(tref.getBundleName()).append("::").append(tref.getKey());
+    for(Object param : params)
+       sb.append(" \"").append(param).append("\"");
+
+    return sb.toString();
   }
 
 
@@ -104,7 +123,7 @@ public final class CatalogHelper
       // the lookup failed, provide a fallback
       result = tref.getBundleName()+"::"+tref.getKey();
     }
-    // ClassCastException intentionally not handled here,
+    // ClassCastException from bundle.getString intentionally not handled here,
     // because TextRef should always refer to a text
 
     return result;

--- a/src/main/java/pityoulish/i18n/CatalogHelper.java
+++ b/src/main/java/pityoulish/i18n/CatalogHelper.java
@@ -90,6 +90,8 @@ public final class CatalogHelper
    *
    * @param tref        text ref of the missing pattern
    * @param params      parameters to format
+   *
+   * @return the arguments in fallback format
    */
   protected static final String fallbackFormat(TextRef tref, Object... params)
   {

--- a/src/test/java/pityoulish/i18n/CatalogHelperTest.java
+++ b/src/test/java/pityoulish/i18n/CatalogHelperTest.java
@@ -53,6 +53,27 @@ public class CatalogHelperTest
     assertEquals("wrong text", UnitTestCatalogData.textB, text);
   }
 
+  @Test public void lookup_EMPTY()
+    throws Exception
+  {
+    String text = UnitTestCatalog.EMPTY.lookup();
+    assertEquals("wrong text", "", text);
+  }
+
+  @Test public void lookup_EMPTY_0()
+    throws Exception
+  {
+    String text = UnitTestCatalog.EMPTY_0.lookup();
+    assertEquals("wrong text", "", text);
+  }
+
+  @Test public void lookup_EMPTY_1()
+    throws Exception
+  {
+    String text = UnitTestCatalog.EMPTY_1.lookup();
+    assertEquals("wrong text", "", text);
+  }
+
   @Test public void lookup_OBJECT()
     throws Exception
   {
@@ -127,6 +148,28 @@ public class CatalogHelperTest
     } catch (IllegalArgumentException iax) {
       // expected
     }
+  }
+
+
+  @Test public void format_EMPTY_0()
+    throws Exception
+  {
+    // expect fallback behavior when the format is empty
+    String text = UnitTestCatalog.EMPTY_0.format();
+    assertEquals("wrong text",
+                 "pityoulish.i18n.UnitTestCatalogData::EMPTY_0", text);
+  }
+
+
+  @Test public void format_EMPTY_1()
+    throws Exception
+  {
+    // expect fallback behavior when the format is empty
+    String text = UnitTestCatalog.EMPTY_1.format("ArgUment");
+    assertTrue("missing entry name",
+               text.indexOf("UnitTestCatalogData::EMPTY_1") >= 0);
+    assertTrue("missing parameter",
+               text.indexOf("ArgUment") >= 0);
   }
 
 

--- a/src/test/java/pityoulish/i18n/UnitTestCatalog.java
+++ b/src/test/java/pityoulish/i18n/UnitTestCatalog.java
@@ -16,6 +16,9 @@ public enum UnitTestCatalog implements TextEntry
      PATTERN_2,
      TEXT_A,
      TEXT_B,
+     EMPTY,
+     EMPTY_0,
+     EMPTY_1,
      OBJECT;
 
    private final static String

--- a/src/test/java/pityoulish/i18n/UnitTestCatalogData.java
+++ b/src/test/java/pityoulish/i18n/UnitTestCatalogData.java
@@ -28,8 +28,12 @@ public class UnitTestCatalogData extends ListResourceBundle
   public final static String textB =
     "Boo!";
 
+  public final static String empty =
+    "";
+
   public final static Object obj =
     new Object();
+
 
   protected Object[][] getContents()
   {
@@ -40,6 +44,9 @@ public class UnitTestCatalogData extends ListResourceBundle
       { "PATTERN_2", pattern2 },
       { "TEXT_A",    textA },
       { "TEXT_B",    textB },
+      { "EMPTY",     empty },
+      { "EMPTY_0",   empty },
+      { "EMPTY_1",   empty },
       { "OBJECT",    obj }
     };
   }


### PR DESCRIPTION
- implement fallback for empty pattern, similar to "entry not found" (see #44)
- let Travis compile the pre-processed sources as well