### PR TITLE
Sockets: handle some errors without exception

### DIFF
--- a/src/main/java/pityoulish/sockets/server/ConsoleExpositorImpl.java
+++ b/src/main/java/pityoulish/sockets/server/ConsoleExpositorImpl.java
@@ -45,12 +45,6 @@ public class ConsoleExpositorImpl implements Expositor
   }
 
 
-  public void describeTicketGrant(String tictok)
-  {
-    System.out.println(Catalog.DESCRIBE_TICKET_GRANT_1.format(tictok));
-  }
-
-
   public void describeTicketGrant(MsgBoardResponse<String> response)
   {
     if (response.isOK())
@@ -61,9 +55,12 @@ public class ConsoleExpositorImpl implements Expositor
   }
 
 
-  public void describeInfoResponse(String info)
+  public void describeInfoResponse(MsgBoardResponse<String> response)
   {
-    // "OK" is implied
+    if (response.isOK())
+       ; // "OK" is implied
+    else
+       System.out.println(response.getProblem()); // is a catalog message
   }
 
 

--- a/src/main/java/pityoulish/sockets/server/ConsoleExpositorImpl.java
+++ b/src/main/java/pityoulish/sockets/server/ConsoleExpositorImpl.java
@@ -35,13 +35,19 @@ public class ConsoleExpositorImpl implements Expositor
   }
 
 
-  public void describeMessageBatch(MessageBatch mb)
+  public void describeMessageBatch(MsgBoardResponse<MessageBatch> response)
   {
-    System.out.println(Catalog.DESCRIBE_MESSAGE_BATCH_2
-                       .format(String.valueOf(mb.getMessages().size()),
-                               mb.getMarker()));
-    // Using String.valueOf on the number avoids locale-specific formatting.
-    // For example, it will print "1234" instead of "1,234" or "1.234".
+    if (response.isOK())
+     {
+       MessageBatch mb = response.getResult();
+       System.out.println(Catalog.DESCRIBE_MESSAGE_BATCH_2
+                          .format(String.valueOf(mb.getMessages().size()),
+                                  mb.getMarker()));
+       // Using String.valueOf on the number avoids locale-specific formatting.
+       // For example, it will print "1234" instead of "1,234" or "1.234".
+     }
+    else
+       System.out.println(response.getProblem()); // is a catalog message
   }
 
 

--- a/src/main/java/pityoulish/sockets/server/ConsoleExpositorImpl.java
+++ b/src/main/java/pityoulish/sockets/server/ConsoleExpositorImpl.java
@@ -51,6 +51,16 @@ public class ConsoleExpositorImpl implements Expositor
   }
 
 
+  public void describeTicketGrant(MsgBoardResponse<String> response)
+  {
+    if (response.isOK())
+       System.out.println(Catalog.DESCRIBE_TICKET_GRANT_1
+                          .format(response.getResult()));
+    else
+       System.out.println(response.getProblem()); // is a catalog message
+  }
+
+
   public void describeInfoResponse(String info)
   {
     // "OK" is implied

--- a/src/main/java/pityoulish/sockets/server/Expositor.java
+++ b/src/main/java/pityoulish/sockets/server/Expositor.java
@@ -36,18 +36,10 @@ public interface Expositor
 
 
   /**
-   * Describe a granted ticket.
-   *
-   * @param tictok   the token representing the ticket
-   */
-  public void describeTicketGrant(String tictok)
-    ;
-
-
-  /**
    * Describe a ticket grant response.
    *
-   * @param response    the response to describe, ticket grant or error
+   * @param response    the response to describe,
+   *                    either ticket grant or error
    */
   public void describeTicketGrant(MsgBoardResponse<String> response)
     ;
@@ -56,9 +48,10 @@ public interface Expositor
   /**
    * Describe an informational response.
    *
-   * @param info   the information being returned to a client
+   * @param response    the response to describe,
+   *                    either informational message or error
    */
-  public void describeInfoResponse(String info)
+  public void describeInfoResponse(MsgBoardResponse<String> response)
     ;
 
 

--- a/src/main/java/pityoulish/sockets/server/Expositor.java
+++ b/src/main/java/pityoulish/sockets/server/Expositor.java
@@ -29,9 +29,10 @@ public interface Expositor
   /**
    * Describe an outgoing message batch.
    *
-   * @param mb   the message batch to describe
+   * @param response    the response to describe,
+   *                    either message batch or error
    */
-  public void describeMessageBatch(MessageBatch mb)
+  public void describeMessageBatch(MsgBoardResponse<MessageBatch> response)
     ;
 
 

--- a/src/main/java/pityoulish/sockets/server/Expositor.java
+++ b/src/main/java/pityoulish/sockets/server/Expositor.java
@@ -45,6 +45,15 @@ public interface Expositor
 
 
   /**
+   * Describe a ticket grant response.
+   *
+   * @param response    the response to describe, ticket grant or error
+   */
+  public void describeTicketGrant(MsgBoardResponse<String> response)
+    ;
+
+
+  /**
    * Describe an informational response.
    *
    * @param info   the information being returned to a client

--- a/src/main/java/pityoulish/sockets/server/MsgBoardRequestHandler.java
+++ b/src/main/java/pityoulish/sockets/server/MsgBoardRequestHandler.java
@@ -67,11 +67,12 @@ public interface MsgBoardRequestHandler
    *       {@link MsgBoardRequest.ReqType#OBTAIN_TICKET OBTAIN_TICKET}
    * @param address     the network address of the client
    *
-   * @return the ticket token
+   * @return response holding the ticket token or an error message
    *
    * @throws ProtocolException  in case of a problem
    */
-  public String obtainTicket(MsgBoardRequest mbreq, InetAddress address)
+  public MsgBoardResponse<String>
+    obtainTicket(MsgBoardRequest mbreq, InetAddress address)
     throws ProtocolException
     ;
 

--- a/src/main/java/pityoulish/sockets/server/MsgBoardRequestHandler.java
+++ b/src/main/java/pityoulish/sockets/server/MsgBoardRequestHandler.java
@@ -35,11 +35,12 @@ public interface MsgBoardRequestHandler
    *       {@link MsgBoardRequest.ReqType#LIST_MESSAGES LIST_MESSAGES}
    * @param address     the network address of the client
    *
-   * @return the batch of listed messages
+   * @return response holding a batch of listed messages or an error message
    *
    * @throws ProtocolException  in case of a problem
    */
-  public MessageBatch listMessages(MsgBoardRequest mbreq, InetAddress address)
+  public MsgBoardResponse<MessageBatch>
+    listMessages(MsgBoardRequest mbreq, InetAddress address)
     throws ProtocolException
     ;
 

--- a/src/main/java/pityoulish/sockets/server/MsgBoardRequestHandler.java
+++ b/src/main/java/pityoulish/sockets/server/MsgBoardRequestHandler.java
@@ -51,11 +51,12 @@ public interface MsgBoardRequestHandler
    *       {@link MsgBoardRequest.ReqType#PUT_MESSAGE PUT_MESSAGE}
    * @param address     the network address of the client
    *
-   * @return an informational text
+   * @return response holding an informational text or error message
    *
    * @throws ProtocolException  in case of a problem
    */
-  public String putMessage(MsgBoardRequest mbreq, InetAddress address)
+  public MsgBoardResponse<String>
+    putMessage(MsgBoardRequest mbreq, InetAddress address)
     throws ProtocolException
     ;
 
@@ -84,11 +85,12 @@ public interface MsgBoardRequestHandler
    *       {@link MsgBoardRequest.ReqType#RETURN_TICKET RETURN_TICKET}
    * @param address     the network address of the client
    *
-   * @return an informational text
+   * @return response holding an informational text or error message
    *
    * @throws ProtocolException  in case of a problem
    */
-  public String returnTicket(MsgBoardRequest mbreq, InetAddress address)
+  public MsgBoardResponse<String>
+    returnTicket(MsgBoardRequest mbreq, InetAddress address)
     throws ProtocolException
     ;
 

--- a/src/main/java/pityoulish/sockets/server/MsgBoardRequestHandler.java
+++ b/src/main/java/pityoulish/sockets/server/MsgBoardRequestHandler.java
@@ -100,11 +100,12 @@ public interface MsgBoardRequestHandler
    *       {@link MsgBoardRequest.ReqType#REPLACE_TICKET REPLACE_TICKET}
    * @param address     the network address of the client
    *
-   * @return the ticket token
+   * @return response holding the ticket token or an error message
    *
    * @throws ProtocolException  in case of a problem
    */
-  public String replaceTicket(MsgBoardRequest mbreq, InetAddress address)
+  public MsgBoardResponse<String>
+    replaceTicket(MsgBoardRequest mbreq, InetAddress address)
     throws ProtocolException
     ;
     

--- a/src/main/java/pityoulish/sockets/server/MsgBoardRequestHandlerImpl.java
+++ b/src/main/java/pityoulish/sockets/server/MsgBoardRequestHandlerImpl.java
@@ -90,7 +90,8 @@ public class MsgBoardRequestHandlerImpl implements MsgBoardRequestHandler
 
     
   // non-javadoc, see interface
-  public String putMessage(MsgBoardRequest mbreq, InetAddress address)
+  public MsgBoardResponse<String>
+    putMessage(MsgBoardRequest mbreq, InetAddress address)
     throws ProtocolException
   {
     if (mbreq == null)
@@ -110,15 +111,16 @@ public class MsgBoardRequestHandlerImpl implements MsgBoardRequestHandler
        problem = mboardSanityChecker.checkText(mbreq.getText());
     //@@@ sanity check for address? Mustn't be null.
     if (problem != null)
-       throw Log.log(logger, "putMessage", new ProtocolException(problem));
-    //@@@ issue #12: report without exception
+     {
+       logger.log(Level.WARNING, problem);
+       return new MsgBoardResponseImpl.Error(problem);
+     }
 
     try {
       Ticket tick = ticketMgr.lookupTicket(mbreq.getTicket(), address);
       if (tick.punch())
        {
          msgBoard.putMessage(tick.getUsername(), mbreq.getText());
-         return Catalog.HANDLER_INFO_OK.lookup();
        }
       else
        {
@@ -136,6 +138,8 @@ public class MsgBoardRequestHandlerImpl implements MsgBoardRequestHandler
                     Catalog.HANDLER_BAD_TICKET_2.asPXwithCause
                     (tx, mbreq.getTicket(), tx.getLocalizedMessage()));
     }
+
+    return new MsgBoardResponseImpl.Info(Catalog.HANDLER_INFO_OK.lookup());
   }
 
     
@@ -183,7 +187,8 @@ public class MsgBoardRequestHandlerImpl implements MsgBoardRequestHandler
 
 
   // non-javadoc, see interface
-  public String returnTicket(MsgBoardRequest mbreq, InetAddress address)
+  public MsgBoardResponse<String>
+    returnTicket(MsgBoardRequest mbreq, InetAddress address)
     throws ProtocolException
   {
     if (mbreq == null)
@@ -200,8 +205,10 @@ public class MsgBoardRequestHandlerImpl implements MsgBoardRequestHandler
     String problem = ticketSanityChecker.checkToken(mbreq.getTicket());
     //@@@ sanity check for address? Mustn't be null.
     if (problem != null)
-       throw Log.log(logger, "returnTicket", new ProtocolException(problem));
-    //@@@ issue #12: report without exception
+     {
+       logger.log(Level.WARNING, problem);
+       return new MsgBoardResponseImpl.Error(problem);
+     }
 
     try {
       Ticket tick = ticketMgr.lookupTicket(mbreq.getTicket(), address);
@@ -213,7 +220,7 @@ public class MsgBoardRequestHandlerImpl implements MsgBoardRequestHandler
                     (tx, mbreq.getTicket(), tx.getLocalizedMessage()));
     }
 
-    return Catalog.HANDLER_INFO_OK.lookup();
+    return new MsgBoardResponseImpl.Info(Catalog.HANDLER_INFO_OK.lookup());
   }
 
     

--- a/src/main/java/pityoulish/sockets/server/MsgBoardRequestHandlerImpl.java
+++ b/src/main/java/pityoulish/sockets/server/MsgBoardRequestHandlerImpl.java
@@ -140,48 +140,8 @@ public class MsgBoardRequestHandlerImpl implements MsgBoardRequestHandler
 
     
   // non-javadoc, see interface
-  public String obtainTicket(MsgBoardRequest mbreq, InetAddress address)
-    throws ProtocolException
-  {
-    if (mbreq == null)
-       throw new NullPointerException("MsgBoardRequest");
-    if (mbreq.getReqType() != ReqType.OBTAIN_TICKET)
-       throw new IllegalArgumentException
-         ("MsgBoardRequest.getReqType()="+mbreq.getReqType());
-    if (mbreq.getOriginator() == null)
-       throw new NullPointerException("MsgBoardRequest.getOriginator()");
-    // other values in mbreq will be ignored
-    if (address == null)
-       throw new NullPointerException("InetAddress");
-
-    // The originator or username must pass multiple sanity checks.
-    // The ticket manager checks are stricter. Check with the message board
-    // first, to allow for problem reports from both sanity checkers.
-    String problem =
-      mboardSanityChecker.checkOriginator(mbreq.getOriginator());
-    if (problem == null)
-       problem = ticketSanityChecker.checkUsername(mbreq.getOriginator());
-    //@@@ sanity check for address? Mustn't be null.
-    if (problem != null)
-       throw Log.log(logger, "obtainTicket", new ProtocolException(problem));
-    //@@@ issue #12: report without exception
-
-    try {
-      Ticket tick = ticketMgr.obtainTicket(mbreq.getOriginator(), address);
-
-      return tick.getToken();
-
-    } catch (TicketException tx) {
-      throw Log.log(logger, "obtainTicket",
-                    Catalog.HANDLER_TICKET_DENIED_2.asPXwithCause
-                    (tx, mbreq.getOriginator(), tx.getLocalizedMessage()));
-    }
-  }
-
-    
-  // non-javadoc, see interface
   public MsgBoardResponse<String>
-    obtainTicket2(MsgBoardRequest mbreq, InetAddress address)
+    obtainTicket(MsgBoardRequest mbreq, InetAddress address)
     throws ProtocolException
   {
     if (mbreq == null)

--- a/src/main/java/pityoulish/sockets/server/MsgBoardRequestHandlerImpl.java
+++ b/src/main/java/pityoulish/sockets/server/MsgBoardRequestHandlerImpl.java
@@ -6,6 +6,7 @@
 package pityoulish.sockets.server;
 
 import java.net.InetAddress;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import pityoulish.logutil.Log;
@@ -178,6 +179,49 @@ public class MsgBoardRequestHandlerImpl implements MsgBoardRequestHandler
   }
 
     
+  // non-javadoc, see interface
+  public MsgBoardResponse<String>
+    obtainTicket2(MsgBoardRequest mbreq, InetAddress address)
+    throws ProtocolException
+  {
+    if (mbreq == null)
+       throw new NullPointerException("MsgBoardRequest");
+    if (mbreq.getReqType() != ReqType.OBTAIN_TICKET)
+       throw new IllegalArgumentException
+         ("MsgBoardRequest.getReqType()="+mbreq.getReqType());
+    if (mbreq.getOriginator() == null)
+       throw new NullPointerException("MsgBoardRequest.getOriginator()");
+    // other values in mbreq will be ignored
+    if (address == null)
+       throw new NullPointerException("InetAddress");
+
+    // The originator or username must pass multiple sanity checks.
+    // The ticket manager checks are stricter. Check with the message board
+    // first, to allow for problem reports from both sanity checkers.
+    String problem =
+      mboardSanityChecker.checkOriginator(mbreq.getOriginator());
+    if (problem == null)
+       problem = ticketSanityChecker.checkUsername(mbreq.getOriginator());
+    //@@@ sanity check for address? Mustn't be null.
+    if (problem != null)
+     {
+       logger.log(Level.WARNING, problem);
+       return new MsgBoardResponseImpl.Error(problem);
+     }
+
+    try {
+      Ticket tick = ticketMgr.obtainTicket(mbreq.getOriginator(), address);
+
+      return new MsgBoardResponseImpl.Ticket(tick.getToken());
+
+    } catch (TicketException tx) {
+      throw Log.log(logger, "obtainTicket",
+                    Catalog.HANDLER_TICKET_DENIED_2.asPXwithCause
+                    (tx, mbreq.getOriginator(), tx.getLocalizedMessage()));
+    }
+  }
+
+
   // non-javadoc, see interface
   public String returnTicket(MsgBoardRequest mbreq, InetAddress address)
     throws ProtocolException

--- a/src/main/java/pityoulish/sockets/server/MsgBoardRequestHandlerImpl.java
+++ b/src/main/java/pityoulish/sockets/server/MsgBoardRequestHandlerImpl.java
@@ -60,7 +60,8 @@ public class MsgBoardRequestHandlerImpl implements MsgBoardRequestHandler
 
 
   // non-javadoc, see interface
-  public MessageBatch listMessages(MsgBoardRequest mbreq, InetAddress address)
+  public MsgBoardResponse<MessageBatch>
+    listMessages(MsgBoardRequest mbreq, InetAddress address)
     throws ProtocolException
   {
     if (mbreq == null)
@@ -82,10 +83,13 @@ public class MsgBoardRequestHandlerImpl implements MsgBoardRequestHandler
     //@@@ sanity check for limit? Mustn't be zero or null.
     //@@@ sanity check for address? Mustn't be null.
     if (problem != null)
-       throw Log.log(logger, "listMessages", new ProtocolException(problem));
-    //@@@ issue #12: report without exception
+     {
+       logger.log(Level.WARNING, problem);
+       return new MsgBoardResponseImpl.BatchError(problem);
+     }
 
-    return msgBoard.listMessages(mbreq.getLimit(), mbreq.getMarker());
+    return new MsgBoardResponseImpl.Batch
+      (msgBoard.listMessages(mbreq.getLimit(), mbreq.getMarker()));
   }
 
     

--- a/src/main/java/pityoulish/sockets/server/MsgBoardRequestHandlerImpl.java
+++ b/src/main/java/pityoulish/sockets/server/MsgBoardRequestHandlerImpl.java
@@ -218,7 +218,8 @@ public class MsgBoardRequestHandlerImpl implements MsgBoardRequestHandler
 
     
   // non-javadoc, see interface
-  public String replaceTicket(MsgBoardRequest mbreq, InetAddress address)
+  public MsgBoardResponse<String>
+    replaceTicket(MsgBoardRequest mbreq, InetAddress address)
     throws ProtocolException
   {
     if (mbreq == null)
@@ -235,8 +236,10 @@ public class MsgBoardRequestHandlerImpl implements MsgBoardRequestHandler
     String problem = ticketSanityChecker.checkToken(mbreq.getTicket());
     //@@@ sanity check for address? Mustn't be null.
     if (problem != null)
-       throw Log.log(logger, "replaceTicket", new ProtocolException(problem));
-    //@@@ issue #12: report without exception
+     {
+       logger.log(Level.WARNING, problem);
+       return new MsgBoardResponseImpl.Error(problem);
+     }
 
     try {
       Ticket tick = ticketMgr.lookupTicket(mbreq.getTicket(), address);
@@ -244,7 +247,7 @@ public class MsgBoardRequestHandlerImpl implements MsgBoardRequestHandler
 
       tick = ticketMgr.obtainTicket(tick.getUsername(), address);
 
-      return tick.getToken();
+      return new MsgBoardResponseImpl.Ticket(tick.getToken());
 
     } catch (TicketException tx) {
       throw Log.log(logger, "returnTicket",

--- a/src/main/java/pityoulish/sockets/server/MsgBoardResponse.java
+++ b/src/main/java/pityoulish/sockets/server/MsgBoardResponse.java
@@ -1,0 +1,46 @@
+/*
+ * This work is released into the Public Domain under the
+ * terms of the Creative Commons CC0 1.0 Universal license.
+ * https://creativecommons.org/publicdomain/zero/1.0/
+ */
+package pityoulish.sockets.server;
+
+
+/**
+ * Represents a response from the Message Board Server.
+ *
+ * This interface allows for returning either an error message or
+ * an object that represents success.
+ */
+public interface MsgBoardResponse<R>
+{
+  /**
+   * Indicates whether this is a successful response.
+   *
+   * @return <code>true</code> for a successful response,
+   *         <code>false</code> for an error response
+   */
+  public boolean isOK()
+    ;
+
+
+  /**
+   * Obtains the success result.
+   * Only valid when {@link #isOK} returns <code>true</code>.
+   *
+   * @return the result
+   */
+  public R getResult()
+    ;
+
+
+  /**
+   * Obtains the error message.
+   * Only valid when {@link #isOK} returns <code>false</code>.
+   *
+   * @return a description of the problem
+   */
+  public String getProblem()
+    ;
+
+}

--- a/src/main/java/pityoulish/sockets/server/MsgBoardResponseImpl.java
+++ b/src/main/java/pityoulish/sockets/server/MsgBoardResponseImpl.java
@@ -5,6 +5,8 @@
  */
 package pityoulish.sockets.server;
 
+import pityoulish.msgboard.MessageBatch;
+
 
 /**
  * Default implementation of {@link MsgBoardResponse}.
@@ -75,6 +77,25 @@ public class MsgBoardResponseImpl<R> implements MsgBoardResponse<R>
       super(tictok);
     }
   }
+
+
+  public static class Batch extends MsgBoardResponseImpl<MessageBatch>
+  {
+    public Batch(MessageBatch mb)
+    {
+      super(mb);
+    }
+  }
+
+
+  public static class BatchError extends MsgBoardResponseImpl<MessageBatch>
+  {
+    public BatchError(String problem)
+    {
+      super(MessageBatch.class, problem);
+    }
+  }
+
 
 
   // non-javadoc, see interface

--- a/src/main/java/pityoulish/sockets/server/MsgBoardResponseImpl.java
+++ b/src/main/java/pityoulish/sockets/server/MsgBoardResponseImpl.java
@@ -1,0 +1,121 @@
+/*
+ * This work is released into the Public Domain under the
+ * terms of the Creative Commons CC0 1.0 Universal license.
+ * https://creativecommons.org/publicdomain/zero/1.0/
+ */
+package pityoulish.sockets.server;
+
+
+/**
+ * Default implementation of {@link MsgBoardResponse}.
+ * Represents a response from the Message Board Server.
+ * This class cannot be instantiated, use the nested classes instead.
+ */
+public class MsgBoardResponseImpl<R> implements MsgBoardResponse<R>
+{
+  protected final R result;
+
+  protected final String problem;
+
+
+  /**
+   * Creates a success response.
+   *
+   * @param what   the result to wrap
+   */
+  private MsgBoardResponseImpl(R what)
+  {
+    if (what == null)
+       throw new NullPointerException("what");
+
+    result = what;
+    problem = null;
+  }
+
+
+  /**
+   * Creates an error response.
+   *
+   * @param clazz   the class that would have been wrapped for success
+   * @param why     a description of the problem
+   */
+  private MsgBoardResponseImpl(Class<? extends R> clazz, String why)
+  {
+    if (why == null)
+       throw new NullPointerException("why");
+    // clazz is not used, but needed for type inference
+
+    result = null;
+    problem = why;
+  }
+
+
+  public static class Error extends MsgBoardResponseImpl<String>
+  {
+    public Error(String problem)
+    {
+      super(String.class, problem);
+    }
+  }
+
+
+  public static class Info extends MsgBoardResponseImpl<String>
+  {
+    public Info(String text)
+    {
+      super(text);
+    }
+  }
+
+
+  public static class Ticket extends MsgBoardResponseImpl<String>
+  {
+    public Ticket(String tictok)
+    {
+      super(tictok);
+    }
+  }
+
+
+  // non-javadoc, see interface
+  public final boolean isOK()
+  {
+    return (problem == null);
+  }
+
+
+  // non-javadoc, see interface
+  public final R getResult()
+  {
+    return result;
+  }
+
+
+  // non-javadoc, see interface
+  public final String getProblem()
+  {
+    return problem;
+  }
+
+
+  /**
+   * Provide a human-readable description of this response.
+   *
+   * @return a description
+   */
+  public String toString()
+  {
+    StringBuilder sb = new StringBuilder(80);
+
+    // strip "pityoulish.sockets.server." from classname
+    sb.append(this.getClass().getName().substring(26));
+
+    if (result != null)
+       sb.append(":+:").append(result);
+    else
+       sb.append(":-:").append(problem);
+
+    return sb.toString();
+  }
+
+}

--- a/src/main/java/pityoulish/sockets/server/RequestHandler.java
+++ b/src/main/java/pityoulish/sockets/server/RequestHandler.java
@@ -35,18 +35,6 @@ public interface RequestHandler
 
 
   /**
-   * Builds a response with an error message.
-   * See also {@link ResponseBuilder#buildErrorResponse(String)}.
-   *
-   * @param msg   the error message
-   *
-   * @return a buffer containing the response data, backed by an array
-   */
-  public ByteBuffer buildErrorResponse(String msg)
-    ;
-
-
-  /**
    * Builds a response with an error message, from an exception.
    * See also {@link ResponseBuilder#buildErrorResponse(Throwable)}.
    *

--- a/src/main/java/pityoulish/sockets/server/RequestHandlerImpl.java
+++ b/src/main/java/pityoulish/sockets/server/RequestHandlerImpl.java
@@ -152,13 +152,6 @@ public class RequestHandlerImpl implements RequestHandler
 
 
   // non-javadoc, see interface
-  public ByteBuffer buildErrorResponse(String msg)
-  {
-    return rspBuilder.buildErrorResponse(msg);
-  }
-
-
-  // non-javadoc, see interface
   public ByteBuffer buildErrorResponse(Throwable cause)
   {
     return rspBuilder.buildErrorResponse(cause);

--- a/src/main/java/pityoulish/sockets/server/RequestHandlerImpl.java
+++ b/src/main/java/pityoulish/sockets/server/RequestHandlerImpl.java
@@ -122,9 +122,16 @@ public class RequestHandlerImpl implements RequestHandler
        } break;
 
        case OBTAIN_TICKET: {
-         String tictok = mbrHandler.obtainTicket(mbreq, address);
-         rhExpositor.describeTicketGrant(tictok);
-         result = rspBuilder.buildTicketGrant(tictok);
+         MsgBoardResponse<String> response =
+           mbrHandler.obtainTicket(mbreq, address);
+         rhExpositor.describeTicketGrant(response);
+         if (response.isOK()) {
+           String tictok = response.getResult();
+           result = rspBuilder.buildTicketGrant(tictok);
+         } else {
+           String problem = response.getProblem();
+           result = rspBuilder.buildErrorResponse(problem);
+         }
        } break;
 
        case RETURN_TICKET: {

--- a/src/main/java/pityoulish/sockets/server/RequestHandlerImpl.java
+++ b/src/main/java/pityoulish/sockets/server/RequestHandlerImpl.java
@@ -125,13 +125,7 @@ public class RequestHandlerImpl implements RequestHandler
          MsgBoardResponse<String> response =
            mbrHandler.obtainTicket(mbreq, address);
          rhExpositor.describeTicketGrant(response);
-         if (response.isOK()) {
-           String tictok = response.getResult();
-           result = rspBuilder.buildTicketGrant(tictok);
-         } else {
-           String problem = response.getProblem();
-           result = rspBuilder.buildErrorResponse(problem);
-         }
+         result = rspBuilder.buildTicketGrant(response);
        } break;
 
        case RETURN_TICKET: {
@@ -141,9 +135,10 @@ public class RequestHandlerImpl implements RequestHandler
        } break;
 
        case REPLACE_TICKET: {
-         String tictok = mbrHandler.replaceTicket(mbreq, address);
-         rhExpositor.describeTicketGrant(tictok);
-         result = rspBuilder.buildTicketGrant(tictok);
+         MsgBoardResponse<String> response =
+           mbrHandler.replaceTicket(mbreq, address);
+         rhExpositor.describeTicketGrant(response);
+         result = rspBuilder.buildTicketGrant(response);
        } break;
 
         //@@@ default case might be invoked after adding more request types

--- a/src/main/java/pityoulish/sockets/server/RequestHandlerImpl.java
+++ b/src/main/java/pityoulish/sockets/server/RequestHandlerImpl.java
@@ -110,9 +110,10 @@ public class RequestHandlerImpl implements RequestHandler
      switch (mbreq.getReqType())
       {
        case LIST_MESSAGES: {
-         MessageBatch mb = mbrHandler.listMessages(mbreq, address);
-         rhExpositor.describeMessageBatch(mb);
-         result = rspBuilder.buildMessageBatch(mb);
+         MsgBoardResponse<MessageBatch> response =
+           mbrHandler.listMessages(mbreq, address);
+         rhExpositor.describeMessageBatch(response);
+         result = rspBuilder.buildMessageBatch(response);
        } break;
 
        case PUT_MESSAGE: {

--- a/src/main/java/pityoulish/sockets/server/RequestHandlerImpl.java
+++ b/src/main/java/pityoulish/sockets/server/RequestHandlerImpl.java
@@ -116,9 +116,10 @@ public class RequestHandlerImpl implements RequestHandler
        } break;
 
        case PUT_MESSAGE: {
-         String info = mbrHandler.putMessage(mbreq, address);
-         rhExpositor.describeInfoResponse(info);
-         result = rspBuilder.buildInfoResponse(info);
+         MsgBoardResponse<String> response =
+           mbrHandler.putMessage(mbreq, address);
+         rhExpositor.describeInfoResponse(response);
+         result = rspBuilder.buildInfoResponse(response);
        } break;
 
        case OBTAIN_TICKET: {
@@ -129,9 +130,10 @@ public class RequestHandlerImpl implements RequestHandler
        } break;
 
        case RETURN_TICKET: {
-         String info = mbrHandler.returnTicket(mbreq, address);
-         rhExpositor.describeInfoResponse(info);
-         result = rspBuilder.buildInfoResponse(info);
+         MsgBoardResponse<String> response =
+           mbrHandler.returnTicket(mbreq, address);
+         rhExpositor.describeInfoResponse(response);
+         result = rspBuilder.buildInfoResponse(response);
        } break;
 
        case REPLACE_TICKET: {

--- a/src/main/java/pityoulish/sockets/server/ResponseBuilder.java
+++ b/src/main/java/pityoulish/sockets/server/ResponseBuilder.java
@@ -55,11 +55,12 @@ public interface ResponseBuilder
   /**
    * Builds a response with a message batch.
    *
-   * @param msgbatch   the message batch
+   * @param response    the response, holding either
+   *                    a message batch or an error message
    *
    * @return a buffer containing the response PDU, backed by an array
    */
-  public ByteBuffer buildMessageBatch(MessageBatch msgbatch)
+  public ByteBuffer buildMessageBatch(MsgBoardResponse<MessageBatch> response)
     ;
 
 

--- a/src/main/java/pityoulish/sockets/server/ResponseBuilder.java
+++ b/src/main/java/pityoulish/sockets/server/ResponseBuilder.java
@@ -21,11 +21,12 @@ public interface ResponseBuilder
   /**
    * Builds a response with an informational message.
    *
-   * @param msg   the info message
+   * @param response    the response, holding either
+   *                    an info or an error message
    *
    * @return a buffer containing the response PDU, backed by an array
    */
-  public ByteBuffer buildInfoResponse(String msg)
+  public ByteBuffer buildInfoResponse(MsgBoardResponse<String> response)
     ;
 
 

--- a/src/main/java/pityoulish/sockets/server/ResponseBuilder.java
+++ b/src/main/java/pityoulish/sockets/server/ResponseBuilder.java
@@ -65,11 +65,13 @@ public interface ResponseBuilder
   /**
    * Builds a response with a ticket grant.
    *
-   * @param tictok  the ticket {@link pityoulish.tickets.Ticket#getToken token}
+   * @param response    the response, holding either ticket
+   *                    {@link pityoulish.tickets.Ticket#getToken token}
+   *                    or an error message
    *
    * @return a buffer containing the response PDU, backed by an array
    */
-  public ByteBuffer buildTicketGrant(String tictok)
+  public ByteBuffer buildTicketGrant(MsgBoardResponse<String> response)
     ;
 
 

--- a/src/main/java/pityoulish/sockets/server/ResponseBuilder.java
+++ b/src/main/java/pityoulish/sockets/server/ResponseBuilder.java
@@ -31,17 +31,6 @@ public interface ResponseBuilder
 
 
   /**
-   * Builds a response with an error message.
-   *
-   * @param msg   the error message
-   *
-   * @return a buffer containing the response PDU, backed by an array
-   */
-  public ByteBuffer buildErrorResponse(String msg)
-    ;
-
-
-  /**
    * Builds a response with an error message, from an exception.
    *
    * @param cause   the exception

--- a/src/main/java/pityoulish/sockets/server/TLVResponseBuilderImpl.java
+++ b/src/main/java/pityoulish/sockets/server/TLVResponseBuilderImpl.java
@@ -197,11 +197,18 @@ public class TLVResponseBuilderImpl implements ResponseBuilder
 
 
   // non-javadoc, see interface
-  public ByteBuffer buildInfoResponse(String msg)
+  public ByteBuffer buildInfoResponse(MsgBoardResponse<String> response)
   {
-    return buildSimpleResponsePDU(MsgBoardType.INFO_RESPONSE,
-                                  MsgBoardType.TEXT,
-                                  msg, true);
+    ByteBuffer pdu = null;
+
+    if (response.isOK())
+       pdu = buildSimpleResponsePDU(MsgBoardType.INFO_RESPONSE,
+                                    MsgBoardType.TEXT,
+                                    response.getResult(), true);
+    else
+       pdu = buildErrorResponse(response.getProblem());
+
+    return pdu;
   }
 
 

--- a/src/main/java/pityoulish/sockets/server/TLVResponseBuilderImpl.java
+++ b/src/main/java/pityoulish/sockets/server/TLVResponseBuilderImpl.java
@@ -196,6 +196,21 @@ public class TLVResponseBuilderImpl implements ResponseBuilder
   }
 
 
+  /**
+   * Builds a response with an error message.
+   *
+   * @param msg   the error message
+   *
+   * @return a buffer containing the response PDU, backed by an array
+   */
+  protected ByteBuffer buildErrorResponse(String msg)
+  {
+    return buildSimpleResponsePDU(MsgBoardType.ERROR_RESPONSE,
+                                  MsgBoardType.TEXT,
+                                  msg, true);
+  }
+
+
   // non-javadoc, see interface
   public ByteBuffer buildInfoResponse(MsgBoardResponse<String> response)
   {
@@ -209,15 +224,6 @@ public class TLVResponseBuilderImpl implements ResponseBuilder
        pdu = buildErrorResponse(response.getProblem());
 
     return pdu;
-  }
-
-
-  // non-javadoc, see interface
-  public ByteBuffer buildErrorResponse(String msg)
-  {
-    return buildSimpleResponsePDU(MsgBoardType.ERROR_RESPONSE,
-                                  MsgBoardType.TEXT,
-                                  msg, true);
   }
 
 

--- a/src/main/java/pityoulish/sockets/server/TLVResponseBuilderImpl.java
+++ b/src/main/java/pityoulish/sockets/server/TLVResponseBuilderImpl.java
@@ -265,11 +265,18 @@ public class TLVResponseBuilderImpl implements ResponseBuilder
 
 
   // non-javadoc, see interface
-  public ByteBuffer buildTicketGrant(String tictok)
+  public ByteBuffer buildTicketGrant(MsgBoardResponse<String> response)
   {
-    return buildSimpleResponsePDU(MsgBoardType.TICKET_GRANT,
-                                  MsgBoardType.TICKET,
-                                  tictok, false);
+    ByteBuffer pdu = null;
+
+    if (response.isOK())
+       pdu = buildSimpleResponsePDU(MsgBoardType.TICKET_GRANT,
+                                    MsgBoardType.TICKET,
+                                    response.getResult(), false);
+    else
+       pdu = buildErrorResponse(response.getProblem());
+
+    return pdu;
   }
 
 }

--- a/src/main/java/pityoulish/tickets/DefaultTSanityChecker.java
+++ b/src/main/java/pityoulish/tickets/DefaultTSanityChecker.java
@@ -109,6 +109,9 @@ public class DefaultTSanityChecker<P> extends SanityCheckerBase<P>
     if (token.length() < 1)
        return problemFactory.newProblem(Catalog.TOKEN_EMPTY);
 
+    //@@@ check whether the token contains @, username before, something after?
+    //@@@ generic "invalid token format" report if anything is wrong
+
     return null;
   }
 

--- a/src/test/java/pityoulish/sockets/server/MsgBoardRequestHandlerImplTest.java
+++ b/src/test/java/pityoulish/sockets/server/MsgBoardRequestHandlerImplTest.java
@@ -37,8 +37,11 @@ public class MsgBoardRequestHandlerImplTest
       (new MixedMessageBoardImpl(8), new DefaultTicketManager());
 
 
-    MessageBatch result = mbrh.listMessages(mbreq, ADDRESS);
+    MsgBoardResponse<MessageBatch> rsp = mbrh.listMessages(mbreq, ADDRESS);
+    assertNotNull("no response", rsp);
+    assertTrue("no success", rsp.isOK());
 
+    MessageBatch result = rsp.getResult();
     assertNotNull("no result", result);
     assertEquals("wrong number of messages", 0, result.getMessages().size());
     assertNotNull("no marker", result.getMarker());
@@ -49,7 +52,8 @@ public class MsgBoardRequestHandlerImplTest
   }
 
 
-  @Test public void listMessages_bad()
+  // test error cases reported as exceptions
+  @Test public void listMessages_illegal()
     throws Exception
   {
     //@@@ use JMockit for prereq objects, instead of creating default impls
@@ -59,16 +63,16 @@ public class MsgBoardRequestHandlerImplTest
 
     try {
       MsgBoardRequest mbreq = null;
-      MessageBatch result = mbrh.listMessages(mbreq, ADDRESS);
-      fail("missing request not detected: " + result);
+      MsgBoardResponse<MessageBatch> rsp = mbrh.listMessages(mbreq, ADDRESS);
+      fail("missing request not detected: " + rsp);
     } catch (RuntimeException expected) {
       // expected
     }
 
     try {
       MsgBoardRequest mbreq = MsgBoardRequestImpl.newObtainTicket("un1t");
-      MessageBatch result = mbrh.listMessages(mbreq, ADDRESS);
-      fail("wrong request type detected: " + result);
+      MsgBoardResponse<MessageBatch> rsp = mbrh.listMessages(mbreq, ADDRESS);
+      fail("wrong request type not detected: " + rsp);
     } catch (RuntimeException expected) {
       // expected
     }
@@ -76,12 +80,30 @@ public class MsgBoardRequestHandlerImplTest
     try {
       MsgBoardRequest mbreq = new MsgBoardRequestImpl
         (ReqType.LIST_MESSAGES, null, null, null, null, null);
-      MessageBatch result = mbrh.listMessages(mbreq, ADDRESS);
-      fail("missing mandatory value not detected: " + result);
+      MsgBoardResponse<MessageBatch> rsp = mbrh.listMessages(mbreq, ADDRESS);
+      fail("missing mandatory value not detected: " + rsp);
     } catch (RuntimeException expected) {
       // expected
     }
   }
+
+
+  // test error cases reported as error responses
+  @Test public void listMessages_bad()
+    throws Exception
+  {
+    //@@@ use JMockit for prereq objects, instead of creating default impls
+    MsgBoardRequestHandler mbrh = new MsgBoardRequestHandlerImpl
+      (new MixedMessageBoardImpl(8), new DefaultTicketManager());
+
+    MsgBoardRequest mbreq = new MsgBoardRequestImpl
+      (ReqType.LIST_MESSAGES, 8, "_marker_", null, null, null);
+    MsgBoardResponse<MessageBatch> rsp = mbrh.listMessages(mbreq, ADDRESS);
+    if (rsp.isOK())
+       fail("bad marker not detected: " + rsp);
+
+  }
+
 
   //@@@ test other handler methods as well
 }

--- a/src/test/java/pityoulish/sockets/server/TLVResponseBuilderImplTest.java
+++ b/src/test/java/pityoulish/sockets/server/TLVResponseBuilderImplTest.java
@@ -84,12 +84,13 @@ public class TLVResponseBuilderImplTest
 
 
 
-  @Test public void buildInfoResponse_text()
+  @Test public void buildInfoResponse_good()
   {
     ResponseBuilder rb = new TLVResponseBuilderImpl();
     String msg = "H\u00e4ppy!"; // a-umlaut
+    MsgBoardResponse<String> rsp = new MsgBoardResponseImpl.Info(msg);
 
-    ByteBuffer buf = rb.buildInfoResponse(msg);
+    ByteBuffer buf = rb.buildInfoResponse(rsp);
     byte[]     pdu = toBytes(buf);
 
     byte[] expected = new byte[]{
@@ -99,6 +100,26 @@ public class TLVResponseBuilderImplTest
       MsgBoardType.TEXT.getTypeByte(), (byte)0x82, (byte)0x00, (byte)0x07,
       (byte)'H', (byte)0xc3, (byte)0xa4,
       (byte)'p', (byte)'p', (byte)'y', (byte)'!'
+    };
+    assertArrayEquals("wrong PDU", expected, pdu);
+  }
+
+
+  @Test public void buildInfoResponse_bad()
+  {
+    ResponseBuilder rb = new TLVResponseBuilderImpl();
+    String msg = "b\u00e4d"; // a-umlaut
+    MsgBoardResponse<String> rsp = new MsgBoardResponseImpl.Error(msg);
+
+    ByteBuffer buf = rb.buildInfoResponse(rsp);
+    byte[]     pdu = toBytes(buf);
+
+    byte[] expected = new byte[]{
+      MsgBoardType.ERROR_RESPONSE.getTypeByte(),
+      (byte)0x82, (byte)0x00, (byte)0x08,
+
+      MsgBoardType.TEXT.getTypeByte(), (byte)0x82, (byte)0x00, (byte)0x04,
+      (byte)'b', (byte)0xc3, (byte)0xa4, (byte)'d'
     };
     assertArrayEquals("wrong PDU", expected, pdu);
   }
@@ -255,12 +276,13 @@ public class TLVResponseBuilderImplTest
   }
 
 
-  @Test public void buildTicketGrant()
+  @Test public void buildTicketGrant_good()
   {
     ResponseBuilder rb = new TLVResponseBuilderImpl();
     String tictok = "tIckEt35";
+    MsgBoardResponse<String> rsp = new MsgBoardResponseImpl.Ticket(tictok);
 
-    ByteBuffer buf = rb.buildTicketGrant(tictok);
+    ByteBuffer buf = rb.buildTicketGrant(rsp);
     byte[]     pdu = toBytes(buf);
 
     byte[] expected = new byte[]{
@@ -270,6 +292,26 @@ public class TLVResponseBuilderImplTest
       MsgBoardType.TICKET.getTypeByte(), (byte)0x82, (byte)0x00, (byte)0x08,
       (byte)'t', (byte)'I', (byte)'c', (byte)'k',
       (byte)'E', (byte)'t', (byte)'3', (byte)'5'
+    };
+    assertArrayEquals("wrong PDU", expected, pdu);
+  }
+
+
+  @Test public void buildTicketGrant_bad()
+  {
+    ResponseBuilder rb = new TLVResponseBuilderImpl();
+    String msg = "b\u00e4d"; // a-umlaut
+    MsgBoardResponse<String> rsp = new MsgBoardResponseImpl.Error(msg);
+
+    ByteBuffer buf = rb.buildTicketGrant(rsp);
+    byte[]     pdu = toBytes(buf);
+
+    byte[] expected = new byte[]{
+      MsgBoardType.ERROR_RESPONSE.getTypeByte(),
+      (byte)0x82, (byte)0x00, (byte)0x08,
+
+      MsgBoardType.TEXT.getTypeByte(), (byte)0x82, (byte)0x00, (byte)0x04,
+      (byte)'b', (byte)0xc3, (byte)0xa4, (byte)'d'
     };
     assertArrayEquals("wrong PDU", expected, pdu);
   }

--- a/src/test/java/pityoulish/sockets/server/TLVResponseBuilderImplTest.java
+++ b/src/test/java/pityoulish/sockets/server/TLVResponseBuilderImplTest.java
@@ -127,7 +127,8 @@ public class TLVResponseBuilderImplTest
 
   @Test public void buildErrorResponse_text()
   {
-    ResponseBuilder rb = new TLVResponseBuilderImpl();
+    // tested method has been removed from ResponseBuilder interface
+    TLVResponseBuilderImpl rb = new TLVResponseBuilderImpl();
     String msg = "b\u00e4d"; // a-umlaut
 
     ByteBuffer buf = rb.buildErrorResponse(msg);


### PR DESCRIPTION
- new interface `MsgBoardResponse` holds either success result or error message
- `MsgBoardRequestHandler` returns the new interface from all hander methods
- `ResponseBuilder` and `Expositor` expect the new interface as arguments
- updated unit tests

closes #12 
