### PR TITLE
Improve formatting on mobile Chrome

### DIFF
--- a/src/main/prose/classroom-setup.html
+++ b/src/main/prose/classroom-setup.html
@@ -7,6 +7,7 @@ https://creativecommons.org/publicdomain/zero/1.0/
 -->
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+<meta name="viewport" content="width=device-width">
 <link rel="stylesheet" type="text/css" href="pityoulish.css" />
 <title>Classroom Setup for all Exercises</title>
 </head>
@@ -118,7 +119,7 @@ on a different machine than the server component.
 
 <p>
 Described here is the
-<a href="https://notalwaysworking.com/all-the-worlds-a-rage/30673"
+<a href="https://notalwaysright.com/all-the-worlds-a-rage/59152/"
    class="covert"
    >Tech Rehearsal</a>,
 to sort out problems with cables, network, and the like.

--- a/src/main/prose/direct-messages.html
+++ b/src/main/prose/direct-messages.html
@@ -7,6 +7,7 @@ https://creativecommons.org/publicdomain/zero/1.0/
 -->
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+<meta name="viewport" content="width=device-width">
 <link rel="stylesheet" type="text/css" href="pityoulish.css" />
 <title>Direct Messages - Functional Description</title>
 </head>

--- a/src/main/prose/ijr-index.html
+++ b/src/main/prose/ijr-index.html
@@ -7,6 +7,7 @@ https://creativecommons.org/publicdomain/zero/1.0/
 -->
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+<meta name="viewport" content="width=device-width">
 <link rel="stylesheet" type="text/css" href="pityoulish.css" />
 <title>Instructions: Message Board with Java RMI</title>
 </head>

--- a/src/main/prose/ijs-index.html
+++ b/src/main/prose/ijs-index.html
@@ -7,6 +7,7 @@ https://creativecommons.org/publicdomain/zero/1.0/
 -->
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+<meta name="viewport" content="width=device-width">
 <link rel="stylesheet" type="text/css" href="pityoulish.css" />
 <title>Instructions: Message Board with Sockets</title>
 </head>

--- a/src/main/prose/java-refresher.html
+++ b/src/main/prose/java-refresher.html
@@ -7,6 +7,7 @@ https://creativecommons.org/publicdomain/zero/1.0/
 -->
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+<meta name="viewport" content="width=device-width">
 <link rel="stylesheet" type="text/css" href="pityoulish.css" />
 <title>Java Refresher</title>
 </head>

--- a/src/main/prose/local-index.html
+++ b/src/main/prose/local-index.html
@@ -7,6 +7,7 @@ https://creativecommons.org/publicdomain/zero/1.0/
 -->
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+<meta name="viewport" content="width=device-width">
 <link rel="stylesheet" type="text/css" href="pityoulish.css" />
 <title>Pityoulish: Internal Links</title>
 </head>

--- a/src/main/prose/message-board.html
+++ b/src/main/prose/message-board.html
@@ -7,6 +7,7 @@ https://creativecommons.org/publicdomain/zero/1.0/
 -->
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+<meta name="viewport" content="width=device-width">
 <link rel="stylesheet" type="text/css" href="pityoulish.css" />
 <title>Message Board - Functional Description</title>
 </head>

--- a/src/main/prose/pityoulish.css
+++ b/src/main/prose/pityoulish.css
@@ -181,9 +181,16 @@ p.abstract {
 
 @media screen {
   p.abstract {
-    margin: 0 17% 1em;
+    margin: 0 8% 1em;
   }
 } /* @media screen */
+
+@media only screen and (min-width:26em) {
+  p.abstract {
+    margin-left: 17%;
+    margin-right: 17%;
+  }
+} /* @media screen not tiny */
 
 @media print {
   p.abstract {
@@ -258,12 +265,17 @@ div.box-right
  border-radius: 12px;
 }
 
+@media only screen and (min-width:44em) {
+  div.box-right {
+    width: 35%;
+    min-width: 26em;
+  }
+}
+
 @media screen {
   div.box-right {
     background-color: #f1f3e6;
     border-color: #4d6251;
-    width: 35%;
-    min-width: 26em;
   }
 
   div.box-right a {
@@ -355,11 +367,18 @@ div.side-note .content {
 /* non-floating boxes ======================================== */
 
 div.box-center {
-  margin: 0.8em 8em;
+  margin: 0.8em 2em;
   padding: 0.2em 1em;
   border: 1px solid;
   border-radius: 5px;
 }
+
+@media only screen and (min-width:44em) {
+  div.box-center {
+    margin-left: 8em;
+    margin-right: 8em;
+  }
+} /* @media screen not tiny */
 
 div.box-center .header {
   display: block;
@@ -413,6 +432,15 @@ div.code {
   margin-top: -1em; /* get rid of the first newline */
   margin-bottom: 1em;
 }
+
+@media only screen and (max-width:44em) {
+  .terminal div.output {
+    overflow: scroll visible;
+  }
+  div.code {
+    overflow: scroll visible;
+  }
+} /* @media screen narrow */
 
 .terminal .emph, .code .emph {
   font-style: normal;

--- a/src/main/prose/pityoulish.css
+++ b/src/main/prose/pityoulish.css
@@ -440,6 +440,9 @@ div.code {
   div.code {
     overflow: scroll visible;
   }
+  pre.pdu {
+    overflow: scroll visible;
+  }
 } /* @media screen narrow */
 
 .terminal .emph, .code .emph {

--- a/src/main/prose/protocol-tlv.html
+++ b/src/main/prose/protocol-tlv.html
@@ -7,6 +7,7 @@ https://creativecommons.org/publicdomain/zero/1.0/
 -->
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+<meta name="viewport" content="width=device-width">
 <link rel="stylesheet" type="text/css" href="pityoulish.css" />
 <title>Message Board - Binary Protocol</title>
 </head>
@@ -109,14 +110,14 @@ a <a href="#0xTkt">Ticket</a> with value "free" and
 a <a href="#0xText">Text</a> with value "Hello!".
 </p>
 
-<pre style="text-align: center;">
+<pre style="text-align: center;" class="pdu">
 Type  Length  <span class="bg1">|--------                 Value                        --------|</span>
  E5  82 00 12 <span class="bg1"> C6  82 00 04 <span class="bg2"> 66 72 65 65 </span>    C0  82 00 06 <span class="bg2"> 48 65 6C 6C 6F 21 </span> </span>
              Type  Length  <span class="bg2">|-- Value --|</span>   Type  Length  <span class="bg2">|----  Value  ----|</span>
 </pre>
 
 <!--
-<pre style="margin-left: 1em;">
+<pre style="margin-left: 1em;" class="pdu">
 Type  Length  |~~~~~~~~                 Value                       ~~~~~~~~|
  E5  82 00 12  C6  82 00 04  66 72 65 65     C0  82 00 06  48 65 6C 6C 6F 21
               Type  Length  |~~ Value ~~|   Type  Length  |~~~~  Value  ~~~~|

--- a/src/main/prose/test-fix-repeat.html
+++ b/src/main/prose/test-fix-repeat.html
@@ -7,6 +7,7 @@ https://creativecommons.org/publicdomain/zero/1.0/
 -->
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+<meta name="viewport" content="width=device-width">
 <link rel="stylesheet" type="text/css" href="pityoulish.css" />
 <title>Test and Fix </title>
 </head>

--- a/src/main/prose/tpj-details.html
+++ b/src/main/prose/tpj-details.html
@@ -7,6 +7,7 @@ https://creativecommons.org/publicdomain/zero/1.0/
 -->
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+<meta name="viewport" content="width=device-width">
 <link rel="stylesheet" type="text/css" href="pityoulish.css" />
 <title>Details: Prepare for Java Exercises </title>
 </head>

--- a/src/main/prose/tpj-index.html
+++ b/src/main/prose/tpj-index.html
@@ -7,6 +7,7 @@ https://creativecommons.org/publicdomain/zero/1.0/
 -->
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+<meta name="viewport" content="width=device-width">
 <link rel="stylesheet" type="text/css" href="pityoulish.css" />
 <title>Tutorial: Prepare for Java Exercises </title>
 </head>

--- a/src/main/prose/xjr-index.html
+++ b/src/main/prose/xjr-index.html
@@ -7,6 +7,7 @@ https://creativecommons.org/publicdomain/zero/1.0/
 -->
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+<meta name="viewport" content="width=device-width">
 <link rel="stylesheet" type="text/css" href="pityoulish.css" />
 <title>Exercise: Message Board Client with Java RMI </title>
 </head>

--- a/src/main/prose/xjs-index.html
+++ b/src/main/prose/xjs-index.html
@@ -7,6 +7,7 @@ https://creativecommons.org/publicdomain/zero/1.0/
 -->
 <head>
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+<meta name="viewport" content="width=device-width">
 <link rel="stylesheet" type="text/css" href="pityoulish.css" />
 <title>Exercise: Message Board Client with Sockets </title>
 </head>


### PR DESCRIPTION
fixes #85 

HTML pages now look decent on my desktop, and on the (simulated) Nexus 5X. There are some intermediate window sizes where things look odd: text overflowing, but no scrollbar yet. But it's better than before, and good enough for me. After all, I'm not a front-end developer.

Fixed a broken external link as well.