### PR TITLE
Enable JavaDoc linting explicitly

### DIFF
--- a/ant/setup.xml
+++ b/ant/setup.xml
@@ -70,6 +70,7 @@
 <presetdef name="jdoc.pty" if:set="use-javadoc-stylesheet">
   <javadoc failonerror="true"
            failonwarning="true"
+           additionalparam="-Xdoclint"
            access="protected"
            stylesheetfile="src/main/prose/pityoulish-jdocs.css"
            nohelp="true"
@@ -81,6 +82,7 @@
 <presetdef name="jdoc.pty" unless:set="use-javadoc-stylesheet">
   <javadoc failonerror="true"
            failonwarning="true"
+           additionalparam="-Xdoclint"
            access="protected"
            nohelp="true"
            encoding="ISO-8859-1"


### PR DESCRIPTION
With this change, Ant JavaDoc tasks on my machine will report the same problems as in Travis.
See #93 for background.