### PR TITLE
Container image for the MessageBoard server

### DIFF
--- a/src/main/java/pityoulish/jrmi/server/Main.java
+++ b/src/main/java/pityoulish/jrmi/server/Main.java
@@ -5,8 +5,6 @@
  */
 package pityoulish.jrmi.server;
 
-import java.util.List;
-import java.util.ArrayList;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 

--- a/src/main/java/pityoulish/msgboard/MixedMessageBoardSync.java
+++ b/src/main/java/pityoulish/msgboard/MixedMessageBoardSync.java
@@ -1,0 +1,78 @@
+/*
+ * This work is released into the Public Domain under the
+ * terms of the Creative Commons CC0 1.0 Universal license.
+ * https://creativecommons.org/publicdomain/zero/1.0/
+ */
+package pityoulish.msgboard;
+
+import pityoulish.mbserver.ProblemFactory;
+
+
+/**
+ * A synchronization wrapper for {@link MixedMessageBoard}.
+ * This wrapper calls the underlying implementation in a thread-safe way.
+ */
+public class MixedMessageBoardSync implements MixedMessageBoard
+{
+  private final MixedMessageBoard board;
+
+
+  /**
+   * Creates a new, thread-safe message board wrapper.
+   *
+   * @param board   the underyling message board implementation,
+   *                which is not required to be thread-safe
+   */
+  public MixedMessageBoardSync(MixedMessageBoard board)
+  {
+    if (board == null)
+       throw new IllegalArgumentException("board is null");
+
+    this.board = board;
+  }
+
+
+  // non-javadoc, see interface UserMessageBoard
+  public synchronized
+    <P> MSanityChecker<P> newSanityChecker(ProblemFactory<P> pf)
+  {
+    return board.newSanityChecker(pf);
+  }
+
+
+  // non-javadoc, see interface MessageBoard
+  public synchronized MessageBatch listMessages(int limit, String marker)
+  {
+    return board.listMessages(limit, marker);
+  }
+
+
+  // non-javadoc, see interface UserMessageBoard
+  public synchronized Message putMessage(String originator, String text)
+  {
+    return board.putMessage(originator, text);
+  }
+
+
+  // non-javadoc, see interface SystemMessageBoard
+  public synchronized Message putSystemMessage(String slot, String text)
+  {
+    return board.putSystemMessage(slot, text);
+  }
+
+
+  // non-javadoc, see interface SystemMessageBoard
+  public synchronized boolean removeSystemMessage(String slot)
+  {
+    return board.removeSystemMessage(slot);
+  }
+
+
+  // non-javadoc, see Object
+  public synchronized String toString()
+  {
+    return "synchronized::" + board.toString();
+  }
+
+}
+

--- a/src/main/java/pityoulish/pod/server/Main.java
+++ b/src/main/java/pityoulish/pod/server/Main.java
@@ -1,0 +1,100 @@
+/*
+ * This work is released into the Public Domain under the
+ * terms of the Creative Commons CC0 1.0 Universal license.
+ * https://creativecommons.org/publicdomain/zero/1.0/
+ */
+package pityoulish.pod.server;
+
+import java.util.logging.Logger;
+import java.util.logging.Level;
+
+import java.rmi.Remote;
+import java.rmi.RemoteException;
+import java.rmi.registry.Registry;
+import java.rmi.registry.LocateRegistry;
+import java.rmi.server.UnicastRemoteObject;
+
+import pityoulish.logutil.Log;
+import pityoulish.logutil.LogConfig;
+import pityoulish.jrmi.api.RegistryNames;
+import pityoulish.jrmi.server.Catalog; // for initial messages on board
+import pityoulish.jrmi.server.RemoteMessageBoardImpl;
+import pityoulish.jrmi.server.RemoteTicketIssuerImpl;
+import pityoulish.msgboard.MixedMessageBoard;
+import pityoulish.msgboard.MixedMessageBoardImpl;
+import pityoulish.sockets.server.SocketHandler;
+import pityoulish.tickets.TicketManager;
+import pityoulish.tickets.DefaultTicketManager;
+
+
+
+/**
+ * Main program for the Message Board server running in a pod.
+ */
+public final class Main
+{
+  protected final static Logger LOGGER = Log.getPackageLogger(Main.class);
+
+  /**
+   * Main entry point.
+   *
+   * @param args        the command line arguments
+   *
+   * @throws Exception  in case of a problem
+   */
+  public static void main(String[] args)
+    throws Exception
+  {
+    int regport = 1088;   // for Java RMI registry, default is 1099
+    int rmiport = 8108;   // for Java RMI exported objects
+    int tlvport = 2888;   // for Sockets with binary TLV protocol
+    int capacity = 8;
+
+    // The server name or IP address has to be set as a system property.
+    // Otherwise, stubs will point to some version of 'localhost' and be
+    // useless on other machines. Report whether the property is set.
+    pityoulish.jrmi.server.Main.checkForHostnameProperty();
+
+    LogConfig.configure(Main.class);
+    LOGGER.log(Level.INFO, "starting Message Board server");
+
+    MixedMessageBoard       mmb  = new MixedMessageBoardImpl(capacity);
+    TicketManager           tim  = new DefaultTicketManager();
+    //@@@ ToDo issue #102: mmb and tim are not thread-safe!
+
+    mmb.putSystemMessage(null, Catalog.SYSMSG_OPEN.lookup());
+    mmb.putSystemMessage(null, Catalog.SYSMSG_CAPACITY_1.format(capacity));
+
+
+    // initialize Java RMI external interface
+
+    RemoteMessageBoardImpl  rmbi = new RemoteMessageBoardImpl(mmb, tim);
+    RemoteTicketIssuerImpl  rtii = new RemoteTicketIssuerImpl(tim);
+
+    Remote rmbistub = UnicastRemoteObject.exportObject(rmbi, rmiport);
+    Remote rtiistub = UnicastRemoteObject.exportObject(rtii, rmiport);
+
+    //@@@ NLS light?
+    System.out.println(rmbistub);
+    System.out.println(rtiistub);
+
+    Registry mainreg =
+      pityoulish.jrmi.server.Main.createDefaultRegistry(regport);
+    mainreg.bind(RegistryNames.MESSAGE_BOARD.lookupName, rmbi);
+    mainreg.bind(RegistryNames.TICKET_ISSUER.lookupName, rtii);
+
+
+    // initialize binary protocol external interface
+
+    SocketHandler shandler =
+      pityoulish.sockets.server.Main.createTLVSocketHandler(mmb, tim);
+    shandler.startup(tlvport, 0); // adjusting the backlog is pointless
+
+    //@@@ NLS light?
+    System.out.println(shandler);
+    System.out.println(shandler.getServerSocket());
+
+    // no planned shutdown
+  }
+
+}

--- a/src/main/java/pityoulish/pod/server/Main.java
+++ b/src/main/java/pityoulish/pod/server/Main.java
@@ -22,6 +22,7 @@ import pityoulish.jrmi.server.RemoteMessageBoardImpl;
 import pityoulish.jrmi.server.RemoteTicketIssuerImpl;
 import pityoulish.msgboard.MixedMessageBoard;
 import pityoulish.msgboard.MixedMessageBoardImpl;
+import pityoulish.msgboard.MixedMessageBoardSync;
 import pityoulish.sockets.server.SocketHandler;
 import pityoulish.tickets.TicketManager;
 import pityoulish.tickets.DefaultTicketManager;
@@ -58,9 +59,10 @@ public final class Main
     LogConfig.configure(Main.class);
     LOGGER.log(Level.INFO, "starting Message Board server");
 
-    MixedMessageBoard       mmb  = new MixedMessageBoardImpl(capacity);
-    TicketManager           tim  = new DefaultTicketManager();
-    //@@@ ToDo issue #102: mmb and tim are not thread-safe!
+    // use a thread-safe wrapper around the unsafe message board impl
+    MixedMessageBoard mmb  =
+      new MixedMessageBoardSync(new MixedMessageBoardImpl(capacity));
+    TicketManager tim  = new DefaultTicketManager();
 
     mmb.putSystemMessage(null, Catalog.SYSMSG_OPEN.lookup());
     mmb.putSystemMessage(null, Catalog.SYSMSG_CAPACITY_1.format(capacity));

--- a/src/pod/Containerfile
+++ b/src/pod/Containerfile
@@ -1,3 +1,7 @@
+# This work is released into the Public Domain under the
+# terms of the Creative Commons CC0 1.0 Universal license.
+# https://creativecommons.org/publicdomain/zero/1.0/
+
 FROM adoptopenjdk:11-jre-openj9
 
 # use a tini init process, for proper signal handling
@@ -16,11 +20,5 @@ ENV CLASSPATH=/opt/pityoulish/classes
 COPY tmp/classes/main $CLASSPATH
 COPY src/main/java $CLASSPATH
 
-
-RUN echo >/opt/pityoulish/run.sh "\
-#!/bin/bash\n\
-java pityoulish.sockets.server.Main\n\
-#java pityoulish.jrmi.server.Main\n\
-" && chmod a=x /opt/pityoulish/run.sh
-
-CMD ["/opt/pityoulish/run.sh"]
+CMD ["-c", \
+     "java -Djava.rmi.server.hostname=127.0.0.1 pityoulish.pod.server.Main"]

--- a/src/pod/Containerfile
+++ b/src/pod/Containerfile
@@ -1,0 +1,26 @@
+FROM adoptopenjdk:11-jre-openj9
+
+# use a tini init process, for proper signal handling
+RUN curl -sS -o /sbin/tini -L \
+         https://github.com/krallin/tini/releases/download/v0.19.0/tini \
+ && SHA256SUM=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c \
+ && echo "$SHA256SUM  /sbin/tini" >/tmp/sha256.txt \
+ && sha256sum -cw /tmp/sha256.txt \
+ && chmod a=rx /sbin/tini \
+ && rm /tmp/sha256.txt
+
+ENTRYPOINT ["/sbin/tini", "--", "/bin/bash"]
+
+# need compiled classes as well as source properties files
+ENV CLASSPATH=/opt/pityoulish/classes
+COPY tmp/classes/main $CLASSPATH
+COPY src/main/java $CLASSPATH
+
+
+RUN echo >/opt/pityoulish/run.sh "\
+#!/bin/bash\n\
+java pityoulish.sockets.server.Main\n\
+#java pityoulish.jrmi.server.Main\n\
+" && chmod a=x /opt/pityoulish/run.sh
+
+CMD ["/opt/pityoulish/run.sh"]

--- a/src/pod/Makefile
+++ b/src/pod/Makefile
@@ -1,0 +1,13 @@
+
+BASEDIR := $(abspath ../.. )
+
+IMAGE_TAG := local/pityoulish-server
+
+
+build:
+	echo "BASEDIR=$(BASEDIR)"
+	podman build -t $(IMAGE_TAG) -f $(abspath Containerfile) $(BASEDIR)
+
+run:
+	podman run --rm -p 2888:2888/tcp  -it $(IMAGE_TAG)
+# need two ports for JRMI, registry and calls:  -p 1088:1088/tcp -p ...

--- a/src/pod/Makefile
+++ b/src/pod/Makefile
@@ -1,3 +1,6 @@
+# This work is released into the Public Domain under the
+# terms of the Creative Commons CC0 1.0 Universal license.
+# https://creativecommons.org/publicdomain/zero/1.0/
 
 BASEDIR := $(abspath ../.. )
 
@@ -8,6 +11,6 @@ build:
 	echo "BASEDIR=$(BASEDIR)"
 	podman build -t $(IMAGE_TAG) -f $(abspath Containerfile) $(BASEDIR)
 
+run: PORTS := -p 1088:1088/tcp -p 8108:8108/tcp -p 2888:2888/tcp
 run:
-	podman run --rm -p 2888:2888/tcp  -it $(IMAGE_TAG)
-# need two ports for JRMI, registry and calls:  -p 1088:1088/tcp -p ...
+	podman run --rm -it $(PORTS) $(IMAGE_TAG)


### PR DESCRIPTION
Define a container image for running a server for both ~classroom~ exercises: Sockets and Java RMI. Part of issue #97.

I'm using `podman` rather than `docker` for building the image, but still in the Docker image format.
Rules for building and running the image locally are in a `Makefile` which expects GNU make.

As defined in this PR, Java RMI will only work with the container running on localhost. I'll figure out how to provide the hostname once I know how to run the image in the Cloud, for this year's online class.