### PR TITLE
Workflow to promote image to IBM Cloud

### DIFF
--- a/.github/workflows/promote-image-to-ibm-cloud.yml
+++ b/.github/workflows/promote-image-to-ibm-cloud.yml
@@ -18,8 +18,8 @@ jobs:
     steps:
 
     - name: Login to IBM Cloud Container Registry
-      run: skopeo login -u iamapikey -p "${{ secrets.IBM_CLOUD_API_KEY }}" \
-                  us.icr.io
+      run: |
+        skopeo login -u iamapikey -p ${{ secrets.IBM_CLOUD_API_KEY }} us.icr.io
 
     - name: Promote image
       run: skopeo copy \

--- a/.github/workflows/promote-image-to-ibm-cloud.yml
+++ b/.github/workflows/promote-image-to-ibm-cloud.yml
@@ -19,13 +19,13 @@ jobs:
 
     - name: Promote image
       run: skopeo copy \
-                  "$GHCR_IMAGE:${{ github.event.inputs.image_tag }}' \
-                  "$ICR_IMAGE:${{ github.event.inputs.image_tag }}' \
+                  "$GHCR_IMAGE:${{ github.event.inputs.image_tag }}" \
+                  "$ICR_IMAGE:${{ github.event.inputs.image_tag }}" \
                   --dest-creds iamapikey:${{ secrets.IBM_CLOUD_API_KEY }}
 
     - name: Retag image as latest
       run: skopeo copy \
-                  "$ICR_IMAGE:${{ github.event.inputs.image_tag }}' \
+                  "$ICR_IMAGE:${{ github.event.inputs.image_tag }}" \
                   "$ICR_IMAGE::latest" \
                   --src-creds iamapikey:${{ secrets.IBM_CLOUD_API_KEY }}
                   --dest-creds iamapikey:${{ secrets.IBM_CLOUD_API_KEY }}

--- a/.github/workflows/promote-image-to-ibm-cloud.yml
+++ b/.github/workflows/promote-image-to-ibm-cloud.yml
@@ -17,16 +17,15 @@ jobs:
 
     steps:
 
-    - name: Login to IBM Cloud Container Registry
-      run: |
-        skopeo login -u iamapikey -p ${{ secrets.IBM_CLOUD_API_KEY }} us.icr.io
-
     - name: Promote image
       run: skopeo copy \
                   "$GHCR_IMAGE:${{ github.event.inputs.image_tag }}' \
-                  "$ICR_IMAGE:${{ github.event.inputs.image_tag }}'
+                  "$ICR_IMAGE:${{ github.event.inputs.image_tag }}' \
+                  --dest-creds iamapikey:${{ secrets.IBM_CLOUD_API_KEY }}
 
     - name: Retag image as latest
       run: skopeo copy \
                   "$ICR_IMAGE:${{ github.event.inputs.image_tag }}' \
-                  "$ICR_IMAGE::latest"
+                  "$ICR_IMAGE::latest" \
+                  --src-creds iamapikey:${{ secrets.IBM_CLOUD_API_KEY }}
+                  --dest-creds iamapikey:${{ secrets.IBM_CLOUD_API_KEY }}

--- a/.github/workflows/promote-image-to-ibm-cloud.yml
+++ b/.github/workflows/promote-image-to-ibm-cloud.yml
@@ -18,14 +18,7 @@ jobs:
     steps:
 
     - name: Promote image
-      run: skopeo copy \
-                  --dest-creds iamapikey:${{ secrets.IBM_CLOUD_API_KEY }} \
-                  "$GHCR_IMAGE:${{ github.event.inputs.image_tag }}" \
-                  "$ICR_IMAGE:${{ github.event.inputs.image_tag }}"
+      run: skopeo copy --dest-creds iamapikey:${{ secrets.IBM_CLOUD_API_KEY }} "$GHCR_IMAGE:${{ github.event.inputs.image_tag }}" "$ICR_IMAGE:${{ github.event.inputs.image_tag }}"
 
     - name: Retag image as latest
-      run: skopeo copy \
-                  --src-creds iamapikey:${{ secrets.IBM_CLOUD_API_KEY }} \
-                  --dest-creds iamapikey:${{ secrets.IBM_CLOUD_API_KEY }} \
-                  "$ICR_IMAGE:${{ github.event.inputs.image_tag }}" \
-                  "$ICR_IMAGE::latest"
+      run: skopeo copy --src-creds iamapikey:${{ secrets.IBM_CLOUD_API_KEY }} --dest-creds iamapikey:${{ secrets.IBM_CLOUD_API_KEY }} "$ICR_IMAGE:${{ github.event.inputs.image_tag }}" "$ICR_IMAGE::latest"

--- a/.github/workflows/promote-image-to-ibm-cloud.yml
+++ b/.github/workflows/promote-image-to-ibm-cloud.yml
@@ -9,22 +9,24 @@ on:
         required:    true
 
 jobs:
-  do_all_steps:
+  promote:
     runs-on: ubuntu-20.04
+    env:
+      GHCR_IMAGE: docker://ghcr.io/rolandweber/pityoulish/server
+      ICR_IMAGE:  docker://us.icr.io/pityoulish/server
+
     steps:
 
-    - name: Echo input
-      run: echo image tag '${{ github.event.inputs.image_tag }}'
+    - name: Login to IBM Cloud Container Registry
+      run: skopeo login -u iamapikey -p "${{ secrets.IBM_CLOUD_API_KEY }}" \
+                  us.icr.io
 
-    - name: Promote and retag image
-      env:
-           GHCR_IMAGE: docker://ghcr.io/rolandweber/pityoulish/server
-           ICR_IMAGE:  docker://us.icr.io/pityoulish/server
-      run: skopeo login us.icr.io --username iamapikey --password \
-                        "${{ secrets.IBM_CLOUD_API_KEY }}" \
-        && skopeo copy \
+    - name: Promote image
+      run: skopeo copy \
                   "$GHCR_IMAGE:${{ github.event.inputs.image_tag }}' \
-                  "$ICR_IMAGE:${{ github.event.inputs.image_tag }}' \
-        && skopeo copy \
+                  "$ICR_IMAGE:${{ github.event.inputs.image_tag }}'
+
+    - name: Retag image as latest
+      run: skopeo copy \
                   "$ICR_IMAGE:${{ github.event.inputs.image_tag }}' \
                   "$ICR_IMAGE::latest"

--- a/.github/workflows/promote-image-to-ibm-cloud.yml
+++ b/.github/workflows/promote-image-to-ibm-cloud.yml
@@ -19,13 +19,13 @@ jobs:
 
     - name: Promote image
       run: skopeo copy \
+                  --dest-creds iamapikey:${{ secrets.IBM_CLOUD_API_KEY }} \
                   "$GHCR_IMAGE:${{ github.event.inputs.image_tag }}" \
-                  "$ICR_IMAGE:${{ github.event.inputs.image_tag }}" \
-                  --dest-creds iamapikey:${{ secrets.IBM_CLOUD_API_KEY }}
+                  "$ICR_IMAGE:${{ github.event.inputs.image_tag }}"
 
     - name: Retag image as latest
       run: skopeo copy \
+                  --src-creds iamapikey:${{ secrets.IBM_CLOUD_API_KEY }} \
+                  --dest-creds iamapikey:${{ secrets.IBM_CLOUD_API_KEY }} \
                   "$ICR_IMAGE:${{ github.event.inputs.image_tag }}" \
-                  "$ICR_IMAGE::latest" \
-                  --src-creds iamapikey:${{ secrets.IBM_CLOUD_API_KEY }}
-                  --dest-creds iamapikey:${{ secrets.IBM_CLOUD_API_KEY }}
+                  "$ICR_IMAGE::latest"

--- a/.github/workflows/promote-image-to-ibm-cloud.yml
+++ b/.github/workflows/promote-image-to-ibm-cloud.yml
@@ -21,4 +21,4 @@ jobs:
       run: skopeo copy --dest-creds iamapikey:${{ secrets.IBM_CLOUD_API_KEY }} "$GHCR_IMAGE:${{ github.event.inputs.image_tag }}" "$ICR_IMAGE:${{ github.event.inputs.image_tag }}"
 
     - name: Retag image as latest
-      run: skopeo copy --src-creds iamapikey:${{ secrets.IBM_CLOUD_API_KEY }} --dest-creds iamapikey:${{ secrets.IBM_CLOUD_API_KEY }} "$ICR_IMAGE:${{ github.event.inputs.image_tag }}" "$ICR_IMAGE::latest"
+      run: skopeo copy --src-creds iamapikey:${{ secrets.IBM_CLOUD_API_KEY }} --dest-creds iamapikey:${{ secrets.IBM_CLOUD_API_KEY }} "$ICR_IMAGE:${{ github.event.inputs.image_tag }}" "$ICR_IMAGE:latest"


### PR DESCRIPTION
one step for #106

For reasons I don't understand, backslashes before line breaks in the run: sections were passed literally to the command, causing syntax errors. For now, I've written the commands into single lines.
In the other workflow I have, the backslash also appears to have been passed to the command, but `make` tolerated it. Or else I'm misinterpreting the log output.